### PR TITLE
Add a LevelFromString method to avoid implementing the switch in the project using xlog

### DIFF
--- a/levels.go
+++ b/levels.go
@@ -14,6 +14,24 @@ const (
 	LevelFatal
 )
 
+// LevelFromString returns the level based on its string representation
+func LevelFromString(l string) Level {
+	switch l {
+	case "debug":
+		return LevelDebug
+	case "info":
+		return LevelInfo
+	case "warn":
+		return LevelWarn
+	case "error":
+		return LevelError
+	case "fatal":
+		return LevelFatal
+	default:
+		return LevelInfo
+	}
+}
+
 // String returns the string representation of the level.
 func (l Level) String() string {
 	switch l {

--- a/levels.go
+++ b/levels.go
@@ -80,3 +80,21 @@ func (l Level) String() string {
 		return strconv.FormatInt(int64(l), 10)
 	}
 }
+
+// MarshalText lets Level implements the TextMarshaler interface used by encoding packages
+func (l Level) MarshalText() ([]byte, error) {
+	switch l {
+	case LevelDebug:
+		return levelBytesDebug, nil
+	case LevelInfo:
+		return levelBytesInfo, nil
+	case LevelWarn:
+		return levelBytesWarn, nil
+	case LevelError:
+		return levelBytesError, nil
+	case LevelFatal:
+		return levelBytesFatal, nil
+	default:
+		return []byte(strconv.FormatInt(int64(l), 10)), nil
+	}
+}

--- a/levels.go
+++ b/levels.go
@@ -1,6 +1,10 @@
 package xlog
 
-import "strconv"
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+)
 
 // Level defines log levels
 type Level int
@@ -12,6 +16,15 @@ const (
 	LevelWarn
 	LevelError
 	LevelFatal
+)
+
+// Log level bytes
+var (
+	levelBytesDebug = []byte("debug")
+	levelBytesInfo  = []byte("info")
+	levelBytesWarn  = []byte("warn")
+	levelBytesError = []byte("error")
+	levelBytesFatal = []byte("fatal")
 )
 
 // LevelFromString returns the level based on its string representation
@@ -30,6 +43,24 @@ func LevelFromString(l string) Level {
 	default:
 		return LevelInfo
 	}
+}
+
+// UnmarshalText lets Level implements the TextUnmarshaler interface used by encoding packages
+func (l *Level) UnmarshalText(text []byte) (err error) {
+	if bytes.Equal(text, levelBytesDebug) {
+		*l = LevelDebug
+	} else if bytes.Equal(text, levelBytesInfo) {
+		*l = LevelInfo
+	} else if bytes.Equal(text, levelBytesWarn) {
+		*l = LevelWarn
+	} else if bytes.Equal(text, levelBytesError) {
+		*l = LevelError
+	} else if bytes.Equal(text, levelBytesFatal) {
+		*l = LevelFatal
+	} else {
+		err = fmt.Errorf("Uknown level %v", string(text))
+	}
+	return
 }
 
 // String returns the string representation of the level.

--- a/levels_test.go
+++ b/levels_test.go
@@ -6,6 +6,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestLevelFromString(t *testing.T) {
+	assert.Equal(t, LevelDebug, LevelFromString("debug"))
+	assert.Equal(t, LevelInfo, LevelFromString("info"))
+	assert.Equal(t, LevelWarn, LevelFromString("warn"))
+	assert.Equal(t, LevelError, LevelFromString("error"))
+	assert.Equal(t, LevelFatal, LevelFromString("fatal"))
+	assert.Equal(t, LevelInfo, LevelFromString("info"))
+}
+
 func TestLevelString(t *testing.T) {
 	assert.Equal(t, "debug", LevelDebug.String())
 	assert.Equal(t, "info", LevelInfo.String())

--- a/levels_test.go
+++ b/levels_test.go
@@ -15,7 +15,7 @@ func TestLevelFromString(t *testing.T) {
 	assert.Equal(t, LevelInfo, LevelFromString("info"))
 }
 
-func TestLevelUnmarshaler(t *testing.T) {
+func TestLevelUnmarshalerText(t *testing.T) {
 	l := Level(-1)
 	err := l.UnmarshalText([]byte("debug"))
 	assert.NoError(t, err)
@@ -42,4 +42,25 @@ func TestLevelString(t *testing.T) {
 	assert.Equal(t, "error", LevelError.String())
 	assert.Equal(t, "fatal", LevelFatal.String())
 	assert.Equal(t, "10", Level(10).String())
+}
+
+func TestLevelMarshalerText(t *testing.T) {
+	b, err := LevelDebug.MarshalText()
+	assert.NoError(t, err)
+	assert.Equal(t, levelBytesDebug, b)
+	b, err = LevelInfo.MarshalText()
+	assert.NoError(t, err)
+	assert.Equal(t, levelBytesInfo, b)
+	b, err = LevelWarn.MarshalText()
+	assert.NoError(t, err)
+	assert.Equal(t, levelBytesWarn, b)
+	b, err = LevelError.MarshalText()
+	assert.NoError(t, err)
+	assert.Equal(t, levelBytesError, b)
+	b, err = LevelFatal.MarshalText()
+	assert.NoError(t, err)
+	assert.Equal(t, levelBytesFatal, b)
+	b, err = Level(10).MarshalText()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("10"), b)
 }

--- a/levels_test.go
+++ b/levels_test.go
@@ -15,6 +15,26 @@ func TestLevelFromString(t *testing.T) {
 	assert.Equal(t, LevelInfo, LevelFromString("info"))
 }
 
+func TestLevelUnmarshaler(t *testing.T) {
+	l := Level(-1)
+	err := l.UnmarshalText([]byte("debug"))
+	assert.NoError(t, err)
+	assert.Equal(t, LevelDebug, l)
+	err = l.UnmarshalText([]byte("info"))
+	assert.NoError(t, err)
+	assert.Equal(t, LevelInfo, l)
+	err = l.UnmarshalText([]byte("warn"))
+	assert.NoError(t, err)
+	assert.Equal(t, LevelWarn, l)
+	err = l.UnmarshalText([]byte("error"))
+	assert.NoError(t, err)
+	assert.Equal(t, LevelError, l)
+	err = l.UnmarshalText([]byte("fatal"))
+	assert.NoError(t, err)
+	assert.Equal(t, LevelFatal, l)
+	assert.Error(t, l.UnmarshalText([]byte("invalid")))
+}
+
 func TestLevelString(t *testing.T) {
 	assert.Equal(t, "debug", LevelDebug.String())
 	assert.Equal(t, "info", LevelInfo.String())


### PR DESCRIPTION
If the log level is a string in the package using `xlog`, it's easier to have a `LevelFromString` method to transform it into a proper `xlog.Level` without having to implement the `switch` itself.