### PR TITLE
add a newline at the end of json loglines

### DIFF
--- a/output.go
+++ b/output.go
@@ -323,7 +323,7 @@ func NewJSONOutput(w io.Writer) Output {
 		if err != nil {
 			return err
 		}
-		_, err = w.Write(b)
+		_, err = w.Write(append(b, '\n'))
 		return err
 	})
 }
@@ -353,7 +353,7 @@ func NewLogstashOutput(w io.Writer) Output {
 		if err != nil {
 			return err
 		}
-		_, err = w.Write(b)
+		_, err = w.Write(append(b, '\n'))
 		return err
 	})
 }

--- a/output_test.go
+++ b/output_test.go
@@ -300,7 +300,7 @@ func TestJSONOutput(t *testing.T) {
 	j := NewJSONOutput(buf)
 	err := j.Write(F{"message": "some message", "level": "info", "foo": "bar"})
 	assert.NoError(t, err)
-	assert.Equal(t, "{\"foo\":\"bar\",\"level\":\"info\",\"message\":\"some message\"}", buf.String())
+	assert.Equal(t, "{\"foo\":\"bar\",\"level\":\"info\",\"message\":\"some message\"}\n", buf.String())
 }
 
 func TestLogstashOutput(t *testing.T) {
@@ -314,7 +314,7 @@ func TestLogstashOutput(t *testing.T) {
 		"foo":     "bar",
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, "{\"@timestamp\":\"2000-01-02T03:04:05Z\",\"@version\":1,\"file\":\"test.go:234\",\"foo\":\"bar\",\"level\":\"INFO\",\"message\":\"some message\"}", buf.String())
+	assert.Equal(t, "{\"@timestamp\":\"2000-01-02T03:04:05Z\",\"@version\":1,\"file\":\"test.go:234\",\"foo\":\"bar\",\"level\":\"INFO\",\"message\":\"some message\"}\n", buf.String())
 }
 
 func TestUIDOutput(t *testing.T) {


### PR DESCRIPTION
I was trying to insert json formatted logs to graylog and noticed that the logs aren't newline seperated.
This little change fixed the issue for me.