### PR TITLE
Customize automatic field names

### DIFF
--- a/xlog.go
+++ b/xlog.go
@@ -114,7 +114,7 @@ type logger struct {
 }
 
 // Common field names for log messages.
-const (
+var (
 	KeyTime    = "time"
 	KeyMessage = "message"
 	KeyLevel   = "level"


### PR DESCRIPTION
I believe that the automatic field names should be editable, like on [zerolog](https://github.com/rs/zerolog)

So I just changed they from `const` to `var`